### PR TITLE
Remove duplicate async dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "debug": "^2.2.0"
   },
   "devDependencies": {
-    "async": "^2.1.2",
     "chai": "^3.5.0",
     "eslint": "^3.8.1",
     "eslint-config-mitmaro": "^2.0.0",


### PR DESCRIPTION
It seems that `async` is declared in both dependencies and devDependencies (with different versions no less).
