### PR TITLE
Reverse arguments to ServerShutdown#shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ closing WebSocket connections on finish of a write.
 
 Registers a server with the library.
 
-### `ServerShutdown.shutdown([force = false][, callback])`
+### `ServerShutdown.shutdown([callback = noop][, force = false])`
 
 Shutdown all the servers registered. If the optional `force` flag is provided and true all connections
 are forecfully disconnected. The `callback` is called once all connections are disconnected and servers

--- a/src/server-shutdown.js
+++ b/src/server-shutdown.js
@@ -25,14 +25,8 @@ class ServerShutdown {
 		server.on('connection', this._serverConnectionHandler);
 	}
 
-	shutdown(force, callback) {
+	shutdown(callback = noop, force = false) {
 		debug('Starting shutdown');
-		if (typeof force === 'function') {
-			/* eslint-disable no-param-reassign */
-			callback = force;
-			force = false;
-			/* eslint-enable no-param-reassign */
-		}
 		const tasks = [];
 
 		for (const server of this.servers) {
@@ -42,7 +36,7 @@ class ServerShutdown {
 		this.stopped = true;
 		async.parallel(tasks, () => {
 			debug('Shutdown complete');
-			(callback || noop)();
+			callback();
 		});
 	}
 

--- a/test/server-shutdown.spec.js
+++ b/test/server-shutdown.spec.js
@@ -264,7 +264,7 @@ describe('ServerShutdown', function() {
 
 		function acceptRequest() {
 			// we do not respond to the client, and force a shutdown
-			setImmediate(serverManager.shutdown.bind(serverManager, true));
+			setImmediate(serverManager.shutdown.bind(serverManager, undefined, true));
 		}
 
 		server.on('listening', createRequest);


### PR DESCRIPTION
This PR reverses the arguments to `ServerShutdown#shutdown`, putting the callback first and the flag 2nd.

There are a few things to this:
1. This optimizes for the common uses cases, e.g.
   - `foo.shutdown();`
   - `foo.shutdown(() => {});`
   - `foo.bind(foo, () => {});`
2. This API is similar to the [`target.addEventListener(type, listener[, useCapture]);`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) which also relegates a lesser-used flag to the last argument
3. Least importantly, this allows the use of [ES6 default parameters](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Default_parameters)
