### PR TITLE
Added `forceShutdown` api method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,15 @@ closing WebSocket connections on finish of a write.
 
 Registers a server with the library. The adapter name argument is used to set the type of server being registered.
 
-#### `ServerShutdown.shutdown([force = false][, callback])`
+#### `ServerShutdown.shutdown([callback])`
 
-Shutdown all the servers registered. If the optional `force` flag is provided and true all connections
-are forecfully disconnected. The `callback` is called once all connections are disconnected and servers
+Shutdown all the servers registered. The `callback` is called once all connections are disconnected and servers
 are closed.
+
+#### `ServerShutdown.forceShutdown([callback])`
+
+Shutdown all the servers registered with all connections forcefully disconnected. The `callback` is called once
+all connections are disconnected and servers are closed.
 
 #### `ServerShutdown.registerAdapter(name, adapter)`
 

--- a/src/server-shutdown.js
+++ b/src/server-shutdown.js
@@ -48,14 +48,16 @@ class ServerShutdown {
 		server.on('secureConnection', (s) => this._serverConnectionHandler(s, adapter));
 	}
 
-	shutdown(force, callback) {
+	shutdown(callback) {
+		this._shutdown(false, callback);
+	}
+
+	forceShutdown(callback) {
+		this._shutdown(true, callback);
+	}
+
+	_shutdown(force, callback) {
 		debug('Starting shutdown');
-		if (typeof force === 'function') {
-			/* eslint-disable no-param-reassign */
-			callback = force;
-			force = false;
-			/* eslint-enable no-param-reassign */
-		}
 		const tasks = [];
 
 		for (const server of this.servers) {

--- a/test/server-shutdown.spec.js
+++ b/test/server-shutdown.spec.js
@@ -278,7 +278,7 @@ describe('ServerShutdown', function() {
 
 			function acceptRequest() {
 				// we do not respond to the client, and force a shutdown
-				setImmediate(serverManager.shutdown.bind(serverManager, true));
+				setImmediate(serverManager.forceShutdown.bind(serverManager));
 			}
 
 			server.on('listening', createRequest);
@@ -483,7 +483,7 @@ describe('ServerShutdown', function() {
 
 			function acceptRequest() {
 				// we do not respond to the client, and force a shutdown
-				setImmediate(serverManager.shutdown.bind(serverManager, true));
+				setImmediate(serverManager.forceShutdown.bind(serverManager, true));
 			}
 
 			server.on('listening', createRequest);


### PR DESCRIPTION
This replaces the `shutdown(true, callback)` api method. This also
means the `shutdown` method does not take a force flag anymore.