### PR TITLE
Delete socket instance from `this.sockets` set on receiving disconnect event

### DIFF
--- a/src/server-shutdown.js
+++ b/src/server-shutdown.js
@@ -80,6 +80,10 @@ class ServerShutdown {
 			debug('Connection ended');
 			this.sockets.delete(socket);
 		});
+        socket.on('disconnect', () => {
+            debug('Socket disconnected');
+            this.sockets.delete(socket);
+        });
 	}
 
 	_socketRequestHandler(req, res) {


### PR DESCRIPTION
This fixes a memory leak caused due to the `disconnect` event not being handled in socket.io connections.